### PR TITLE
Set new header values regardless of header_params (fixes basic authentication)

### DIFF
--- a/lib/wadl/address.rb
+++ b/lib/wadl/address.rb
@@ -131,10 +131,7 @@ module WADL
       }
 
       # Bind header variables to header parameters
-      header_var_values.each { |name, value|
-        param = header_params.delete(name.to_s)
-        headers[name] = param % value if param
-      }
+      headers.merge!(header_var_values)
 
       self
     end


### PR DESCRIPTION
This patch fixes basic authentication. It didn't work because header_params is set to {}, which means param will be nil and thus headers["Authorization"] doesn't get set. Param.default.format should not be used (as around line 99 of address.rb), since HTML escaping should not be done on headers.

It seems query_vars is not being set correctly either, but in that case, Param.default.format probably should be used. This patch does not address that issue. Since I don't (yet) use query_vars, I have not looked into it in detail.
