### PR TITLE
Update lib/wadl/address.rb

### DIFF
--- a/lib/wadl/address.rb
+++ b/lib/wadl/address.rb
@@ -87,7 +87,7 @@ module WADL
 
       # This patch solves and issue regarding basic_auth and the use of uri template params
       #  This way, path params are never evaluated if they are not set (like in with_basic_auth/2) 
-      if(path_var_values.length > 0)  path_fragments.each { |fragment|
+      if(path_var_values.length > 0) then path_fragments.each { |fragment|
         if fragment.respond_to?(:to_str)
           # This fragment is a string which might contain {} substitutions.
           # Make any substitutions available to the provided path variables.

--- a/lib/wadl/address.rb
+++ b/lib/wadl/address.rb
@@ -85,7 +85,9 @@ module WADL
       # Bind variables found in the path fragments.
       path_params_to_delete = []
 
-      path_fragments.each { |fragment|
+      # This patch solves and issue regarding basic_auth and the use of uri template params
+      #  This way, path params are never evaluated if they are not set (like in with_basic_auth/2) 
+      if(path_var_values.length > 0)  path_fragments.each { |fragment|
         if fragment.respond_to?(:to_str)
           # This fragment is a string which might contain {} substitutions.
           # Make any substitutions available to the provided path variables.
@@ -118,7 +120,7 @@ module WADL
             end
           }
         end
-      }
+      } end
 
       # Delete any embedded path parameters that are now bound from
       # our list of unbound parameters.


### PR DESCRIPTION
There is an issue with resources that require basic_auth, and have template parameters in its URI.
This way, if there are not path parameters in the args, all the section of the code is ignored (also, more efficient)

Typical problem that is solved:
driver.resource(:service_id_json).with_basic_auth('u1','u1').bind(:path => {:id => id})
